### PR TITLE
Add option to ignore log truncation when parsing txs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zetamarkets_py"
-version = "0.2.5"
+version = "0.2.6"
 description = "Python SDK for Zeta Markets"
 license = "apache-2.0"
 authors = ["Tristan0x <tristan@sierra.team>"]

--- a/zetamarkets_py/client.py
+++ b/zetamarkets_py/client.py
@@ -520,6 +520,8 @@ class Client:
         Args:
             commitment (Optional[Commitment], optional): The commitment level to use for the subscription.
                 Defaults to None.
+            ignore_truncation(bool): Bool to ignore the "Logs truncated, missing event data" warning.
+                Defaults to False.
 
         Yields:
             List[ZetaEvent]: A list of ZetaEvents that are yielded as they are received.
@@ -582,6 +584,7 @@ class Client:
 
         Args:
             msg: The message received from the websocket.
+            ignore_truncation: Bool to ignore the "Logs truncated, missing event data" warning. Defaults to False.
 
         Returns:
             Tuple[List[ZetaEvent], int]: A tuple containing a list of ZetaEnrichedEvent and the slot number.
@@ -628,7 +631,7 @@ class Client:
             if log_messages[i] == "Log truncated":
                 if ignore_truncation:
                     break
-                raise Exception("Logs truncated, missing event data")
+                self._logger.warning("Logs truncated, missing event data")
             if log_messages[i].endswith("invoke [1]"):
                 split_indices.append(i)
 


### PR DESCRIPTION
If listening to events with an MM you'll get a lot of log truncated errors which are spammy. Add option to ignore these errors and just parse whatever events we can. Usually the important events (trade) will be in the first ixs anyway so it's fine 😊 

Defaults to false because this is advanced, normal users should be warned about truncation by default IMO.