### PR TITLE
Improve log truncation handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zetamarkets_py"
-version = "0.2.7"
+version = "0.2.8"
 description = "Python SDK for Zeta Markets"
 license = "apache-2.0"
 authors = ["Tristan0x <tristan@sierra.team>"]

--- a/zetamarkets_py/client.py
+++ b/zetamarkets_py/client.py
@@ -642,7 +642,9 @@ class Client:
         if len(split_log_messages) > 0:
             split_log_messages = split_log_messages[1:]
 
-        if len(ix_args) != len(split_log_messages) or len(ix_names) != len(split_log_messages):
+        if not ignore_truncation and (
+            len(ix_args) != len(split_log_messages) or len(ix_names) != len(split_log_messages)
+        ):
             raise Exception("Mismatched transaction info lengths")
 
         # For each individual instruction, find the ix name and the events


### PR DESCRIPTION
We get this error when we see truncated logs. We just wanna ignore it and process whatever events we can.
<img width="975" alt="image" src="https://github.com/zetamarkets/zetamarkets-py/assets/103913117/041a371c-f642-490f-8d2c-b7e98169c28b">
