### PR TITLE
Fix: list.extend was called with a non iterable argument.

### DIFF
--- a/zetamarkets_py/client.py
+++ b/zetamarkets_py/client.py
@@ -1150,7 +1150,7 @@ class Client:
         pre_ixs = []
         if priority_fee > 0:
             pre_ixs.extend([set_compute_unit_price(priority_fee)])
-        pre_ixs.extend(self._cancel_orders_for_market_ix(asset))
+        pre_ixs.extend([self._cancel_orders_for_market_ix(asset)])
         return await self.place_orders_for_market(asset, orders, pre_instructions=pre_ixs)
 
     # TODO: liquidate


### PR DESCRIPTION
The issue was discovered when testing `examples/market_maker.py`.

It caused the following error message :

```
An unexpected error occurred: 'solders.instruction.Instruction' object is not iterable
```