### PR TITLE
fix: documentation github link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ html_context = {
     "current_version": "latest",
     "conf_py_path": "/docs/source",
     "display_github": True,
-    "github_user": "0xtristan",
+    "github_user": "zetamarkets",
     "github_repo": "zetamarkets-py",
     "github_version": "master",
     "slug": "zetamarkets_py",


### PR DESCRIPTION
The github icon in the documentation links to https://github.com/0xtristan/zetamarkets-py but it should link to https://github.com/zetamarkets/zetamarkets-py