### PR TITLE
Fix new user deposit flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zetamarkets_py"
-version = "0.2.29"
+version = "0.2.30"
 description = "Python SDK for Zeta Markets"
 license = "apache-2.0"
 authors = ["Tristan0x <tristan@sierra.team>"]


### PR DESCRIPTION
The checks for if an account exists were broken for a brand new user account
- Only add to `_account_exists_cache` if `exists` is true
- Change code to check the right address, not just margin_account_manager_address

Tested locally on a fresh wallet:
- Deposited correctly the first time
- Did another run with 2 deposits, first one didn't use the account_exists skip but the second one did (added some temp logging)