### PR TITLE
Add ability to listen to all events/transactions

### DIFF
--- a/examples/subscribe_event.py
+++ b/examples/subscribe_event.py
@@ -28,7 +28,10 @@ async def main():
 
     # Subscribe to margin account events
     print(f"Listening for events on margin account: {client._margin_account_address} (authority: {wallet.public_key})")
-    async for events, _ in client.subscribe_events():
+    async for events, _ in client.subscribe_events(
+        # Listen to all events across Zeta by setting the following argument:
+        # ignore_third_party_events=False
+    ):
         # Loop over the events in each tx
         for event in events:
             # Event can be PlaceOrder, Trade, OrderComplete or Liquidate

--- a/examples/subscribe_transaction.py
+++ b/examples/subscribe_transaction.py
@@ -33,7 +33,10 @@ async def main():
 
     # Subscribe to margin account transactions
     print(f"Listening for transactions on margin account: {client._margin_account_address}")
-    async for tx_events, _ in client.subscribe_transactions():
+    async for tx_events, _ in client.subscribe_transactions(
+        # Listen to all transactions across Zeta by setting the following arguments:
+        # ignore_truncation=True, ignore_third_party_transactions=False
+    ):
         # Loop over the events in each tx
         for event in tx_events:
             # Event can be PlaceOrder, Trade, OrderComplete or Liquidate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zetamarkets_py"
-version = "0.2.40"
+version = "0.2.41"
 description = "Python SDK for Zeta Markets"
 license = "apache-2.0"
 authors = ["Tristan0x <tristan@sierra.team>"]

--- a/zetamarkets_py/client.py
+++ b/zetamarkets_py/client.py
@@ -197,11 +197,13 @@ class Client:
         if double_down_endpoints:
             for endpoint in double_down_endpoints:
                 connection = AsyncClient(endpoint=endpoint, commitment=commitment, blockhash_cache=blockhash_cache)
-                double_down_providers.append(Provider(
-                    connection,
-                    wallet,
-                    tx_opts,
-                ))
+                double_down_providers.append(
+                    Provider(
+                        connection,
+                        wallet,
+                        tx_opts,
+                    )
+                )
 
         # additional addresses to cache
         _combined_vault_address = pda.get_combined_vault_address(exchange.program_id)
@@ -455,8 +457,7 @@ class Client:
 
     # TODO: maybe at some point support subscribing to all exchange events, not just margin account
     async def subscribe_events(
-        self,
-        commitment: Optional[Commitment] = None,
+        self, commitment: Optional[Commitment] = None, ignore_third_party_events: bool = True
     ) -> AsyncIterator[Tuple[List[ZetaEvent], EventMeta]]:
         """
         Subscribe to events and yield event data and slot.
@@ -467,7 +468,7 @@ class Client:
         Yields:
             AsyncIterator[Tuple[List[ZetaEvent], int]]: An async iterator that yields tuples of event data and slot.
         """
-        if self._margin_account_address is None:
+        if ignore_third_party_events and self._margin_account_address is None:
             raise Exception("Margin account not loaded, cannot subscribe to events")
         commitment = commitment or self.connection.commitment
         async for ws in connect(self.ws_endpoint):
@@ -475,13 +476,15 @@ class Client:
                 # Subscribe to logs that mention the margin account
                 await ws.logs_subscribe(  # type: ignore
                     commitment=commitment,
-                    filter_=RpcTransactionLogsFilterMentions(self._margin_account_address),
+                    filter_=RpcTransactionLogsFilterMentions(
+                        self._margin_account_address if ignore_third_party_events else self.exchange.program_id
+                    ),
                 )
                 first_resp = await ws.recv()
                 subscription_id = cast(int, first_resp[0].result)  # type: ignore
                 async for msg in ws:
                     try:
-                        events, meta = self._parse_event_payload(msg)
+                        events, meta = self._parse_event_payload(msg, ignore_third_party_events)
                         if len(events) > 0 or not meta.is_successful:
                             yield events, meta
 
@@ -493,7 +496,7 @@ class Client:
                 self._logger.warning("Websocket closed, reconnecting...")
                 continue
 
-    def _parse_event_payload(self, msg) -> Tuple[List[ZetaEvent], EventMeta]:
+    def _parse_event_payload(self, msg, ignore_third_party_events: bool = True) -> Tuple[List[ZetaEvent], EventMeta]:
         """
         Parse the event payload from the message.
 
@@ -516,7 +519,7 @@ class Client:
         for event in parsed:
             if event.name.startswith(PlaceOrderEvent.__name__):
                 place_order_event = PlaceOrderEvent.from_event(event)
-                if place_order_event.margin_account == self._margin_account_address:
+                if not ignore_third_party_events or place_order_event.margin_account == self._margin_account_address:
                     events.append(place_order_event)
             elif event.name.startswith(OrderCompleteEvent.__name__):
                 order_complete_event = OrderCompleteEvent.from_event(event)
@@ -526,19 +529,22 @@ class Client:
                     or order_complete_event.order_complete_type == OrderCompleteType.Booted
                 ):
                     cancel_event = CancelOrderEvent.from_order_complete_event(order_complete_event)
-                    if cancel_event.margin_account == self._margin_account_address:
+                    if not ignore_third_party_events or cancel_event.margin_account == self._margin_account_address:
                         events.append(cancel_event)
             elif event.name.startswith(TradeEvent.__name__):
                 trade_event = TradeEvent.from_event(event)
-                if trade_event.margin_account == self._margin_account_address:
+                if not ignore_third_party_events or trade_event.margin_account == self._margin_account_address:
                     events.append(trade_event)
             elif event.name.startswith(LiquidationEvent.__name__):
                 liquidation_event = LiquidationEvent.from_event(event)
-                if liquidation_event.liquidatee_margin_account == self._margin_account_address:
+                if (
+                    not ignore_third_party_events
+                    or liquidation_event.liquidatee_margin_account == self._margin_account_address
+                ):
                     events.append(liquidation_event)
             elif event.name.startswith(ApplyFundingEvent.__name__):
                 funding_event = ApplyFundingEvent.from_event(event)
-                if funding_event.margin_account == self._margin_account_address:
+                if not ignore_third_party_events or funding_event.margin_account == self._margin_account_address:
                     events.append(funding_event)
             else:
                 pass
@@ -546,7 +552,10 @@ class Client:
         return events, meta
 
     async def subscribe_transactions(
-        self, commitment: Optional[Commitment] = None, ignore_truncation: bool = False
+        self,
+        commitment: Optional[Commitment] = None,
+        ignore_truncation: bool = False,
+        ignore_third_party_transactions: bool = True,
     ) -> AsyncIterator[Tuple[List[ZetaEnrichedEvent], EventMeta]]:
         """
         This method is used to subscribe to transactions.
@@ -580,7 +589,13 @@ class Client:
                     "transactionSubscribe",
                     params=[
                         {
-                            "mentions": [str(self._margin_account_address)],
+                            "mentions": [
+                                (
+                                    str(self._margin_account_address)
+                                    if ignore_third_party_transactions
+                                    else str(self.exchange.program_id)
+                                )
+                            ],
                             # "failed": False,
                             "vote": False,
                         },
@@ -596,7 +611,9 @@ class Client:
 
                 async for msg in ws:
                     try:
-                        events, meta = self._parse_transaction_payload(msg, ignore_truncation)
+                        events, meta = self._parse_transaction_payload(
+                            msg, ignore_truncation, ignore_third_party_transactions
+                        )
                         if len(events) > 0 or not meta.is_successful:
                             yield events, meta
                     except Exception:
@@ -613,7 +630,7 @@ class Client:
                 continue
 
     def _parse_transaction_payload(
-        self, msg, ignore_truncation: bool = False
+        self, msg, ignore_truncation: bool = False, ignore_third_party_transactions: bool = True
     ) -> Tuple[List[ZetaEnrichedEvent], EventMeta]:
         """
         Parse the transaction payload from the message.
@@ -621,6 +638,7 @@ class Client:
         Args:
             msg: The message received from the websocket.
             ignore_truncation: Bool to ignore the "Logs truncated, missing event data" warning. Defaults to False.
+            ignore_third_party_transactions: Bool to ignore transactions from other users, filtering by margin account address
 
         Returns:
             Tuple[List[ZetaEvent], int]: A tuple containing a list of ZetaEnrichedEvent and the slot number.
@@ -697,13 +715,14 @@ class Client:
             for event in events:
                 # Skip event that aren't for our account but mention our account
                 # eg if we do a taker trade, we want to skip the maker crank events
-                account_check = (
-                    str(event.data.liquidatee_margin_account)
-                    if ix_name.startswith("liquidation")
-                    else str(event.data.margin_account)
-                )
-                if account_check != str(self._margin_account_address):
-                    continue
+                if ignore_third_party_transactions:
+                    account_check = (
+                        str(event.data.liquidatee_margin_account)
+                        if ix_name.startswith("liquidation")
+                        else str(event.data.margin_account)
+                    )
+                    if account_check != str(self._margin_account_address):
+                        continue
 
                 if ix_name.startswith("place_perp_order"):
                     if event.name.startswith(TradeEvent.__name__):
@@ -855,13 +874,13 @@ class Client:
         Args:
             amount (float): The amount to withdraw.
             priority_fee (int): Additional priority fee, in microlamports per CU. Defaults to 0.
-            
+
         Raises:
             Exception: If the user does not have a USDC account.
-        
+
         Returns:
             Transaction: The transaction object of the withdrawal operation.
-        
+
         """
         ixs = []
         if priority_fee > 0:
@@ -874,7 +893,7 @@ class Client:
 
         self._logger.info(f"Withdrawing {amount} USDC from margin account")
         return await self._send_versioned_transaction(ixs)
-    
+
     def _withdraw_ix(self, amount: float) -> Instruction:
         """
         Withdraw instruction.
@@ -1274,7 +1293,7 @@ class Client:
         try:
             opts = self.provider.opts._replace(last_valid_block_height=last_valid_block_height)
             if len(self.double_down_providers) > 0:
-                tasks = [] 
+                tasks = []
                 for provider in self.double_down_providers:
                     tasks.append(provider.send(tx, opts))
                 signature = await asyncio.gather(*tasks)

--- a/zetamarkets_py/constants.py
+++ b/zetamarkets_py/constants.py
@@ -41,7 +41,7 @@ FLEXIBLE_MINTS = {
         Asset.SEI: Pubkey.from_string("CTw2xSSAfrv9hJGVpB2R2q5xYrdX79i3hXeCiQiAKf2f"),
         Asset.JUP: Pubkey.from_string("7uP5h7kxRaSbd2dz5e6gZp8yhqazyMvaXVoNZ4HsgZ2n"),
         Asset.DYM: Pubkey.from_string("FxxBzHfSZc794sRw6aLs7KuaG9iBy1hSLLFV8LLQYAiL"),
-        Asset.STRK: Pubkey.from_string("C42HXAXQiV6EqxzTvmwff6FgCPNw7r2MgvJ9uv8UNdce")
+        Asset.STRK: Pubkey.from_string("C42HXAXQiV6EqxzTvmwff6FgCPNw7r2MgvJ9uv8UNdce"),
     },
 }
 

--- a/zetamarkets_py/pda.py
+++ b/zetamarkets_py/pda.py
@@ -7,6 +7,7 @@ from zetamarkets_py.types import Network
 
 TOKEN_PROGRAM_ID = Pubkey.from_string("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
 
+
 def get_state_address(program_id: Pubkey) -> Pubkey:
     return Pubkey.find_program_address([b"state"], program_id)[0]
 

--- a/zetamarkets_py/risk.py
+++ b/zetamarkets_py/risk.py
@@ -22,9 +22,11 @@ def compute_upnl(margin_account: CrossMarginAccount, pricing_account: Pricing) -
 
     upnl = sum(
         [
-            (pos.size * mark_price - pos.cost_of_trades)
-            if pos.size > 0
-            else (pos.size * mark_price + pos.cost_of_trades)
+            (
+                (pos.size * mark_price - pos.cost_of_trades)
+                if pos.size > 0
+                else (pos.size * mark_price + pos.cost_of_trades)
+            )
             for pos, mark_price in zip(positions, mark_prices)
         ]
     )


### PR DESCRIPTION
- New argument `ignore_third_party_events` and `ignore_third_party_transactions` that defaults to true. If false, we listen to all Zeta events/transactions.
- A bunch of formatting/linting across other files